### PR TITLE
Major updates for plotting, DB access, and ML model architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# PollutionModelling Project
+# Deep Learning for PDE-based Models
+
+Consider a complex non-linear forecasting problem, e.g. from weather- and air pollution data. A general issue with those problems is that forecasting methods based on solving partial differential equations (PDEs) require a lot of computing power in the model-application phase, especially for applications to large domains, where domain decomposition methods are applied. An idea to circumvent this issue is to use deep-learning techniques to reduce the run-time of the model-application phase at a cost of increasing the run-time of the model-training phase. In this project, we propose domain decomposition methods to scale the deep-learning model to larger domains by imposing consistency constraints during the training across sub-domain boundaries. We demonstrate the methods at the example of an air pollution forecasting problem, which is governed by an advection-diffusion process and described through a PDE.
+
+If you use the code, please also cite our paper: https://arxiv.org/abs/1810.09425
+
+The databases are currently not supplemented since they are proprietary. We are working on providing artificially generated replacements. 
+
 Any questions can be directed to Philipp Hähnel, `phahnel@hsph.harvard.edu`.
 
 
@@ -6,7 +13,8 @@ Any questions can be directed to Philipp Hähnel, `phahnel@hsph.harvard.edu`.
 ## Set-up
 
 ### Requirements
-- Install Python 3. We recommend anaconda from: https://www.anaconda.com/download/ to simplify the development environment
+
+- Install Python 3. We recommend anaconda from: https://www.anaconda.com/download/ to simplify the setup of the development environment
 - Create an anaconda environment using the supplemented environment file
 
       conda env create -f environment.yml
@@ -18,7 +26,7 @@ Any questions can be directed to Philipp Hähnel, `phahnel@hsph.harvard.edu`.
       conda activate pollution_modelling
         
     If you use an IDE, e.g. PyCharm, choose this environment as project interpreter. Otherwise just run the scripts (see below) with that environment active from the command line.
-- The compressed database collections for the pollution measurements, the traffic volumes, and the weather data are located in the folder `PollutionModelling/data/databases`. To use them, we need to install MongoDB.
+- The compressed database collections for the pollution measurements, the traffic volumes, and the weather data are located in the folder `PollutionModelling/data/databases`. To use them, install MongoDB.
 
     Create folders
 
@@ -49,45 +57,87 @@ and install it. Alternatively, on MacOS use
     Check 
     https://docs.mongodb.com/manual/reference/program/mongoimport/ for more info.
 
-- Caline is a Windows executable. If on MacOS, in order to run Caline, install XQuartz >=2.7.11 and WineHQ >=4.7. Check the `PollutionModelling/caline/wine_wrapper.sh` whether the path points to the right directory for the installed Wine version. Also check
-    https://wiki.winehq.org/MacOS_FAQ for further info. The first time you run Wine it may want to automatically install a few more packages. After that, Caline should be able to run on MacOS. The Linux set-up should be similar.
-
 - If you want to look at the data and browse through it, get Robo3T GUI from 
 https://robomongo.org/
 and connect to port `27018` to check out the database.
 
 
+### Requirements (Part 2, not supplemented for now)
+
+If you are also interested in running the PDE solver Caline 4.0 to generate some training data for the deep learning model, then there is an additional requirement needed:
+
+- Caline is a Windows executable. If on MacOS, in order to run Caline, install XQuartz >=2.7.11 and WineHQ >=4.7. Check the `PollutionModelling/caline/wine_wrapper.sh` whether the path points to the right directory for the installed Wine version. Also check
+    https://wiki.winehq.org/MacOS_FAQ for further info. The first time you run Wine it may want to automatically install a few more packages. After that, Caline should be able to run on MacOS. The Linux set-up should be similar.
+
+
 
 ## Getting Started
 
-If the set-up has been successfully completed, we can start running some scripts. First off, let's run some tests to see if everything works:
+If the set-up has been successfully completed, you can start running some scripts. 
 
-    python -m pytest unit_tests/
 
-Next, we can prepare the input data:
+### From Scratch
+
+Not all of the listed scripts and steps are supplemented in this repository. We include them here to allow the user to follow and understand the steps of how the data was generated.
+
+The input data has been prepared using
 
     python run/process_weather.py
     python run/process_traffic.py
     python run/process_measurements.py
     
-The weather data and traffic data might have broken API's. Therefore, it is better to import the Mongo collections given in `data/databases`. From the pollution measurements we find:
+You can also just import the MongoDB collections given in `data/databases`. From the pollution measurements we find:
 
     - NO2:  {min: 0.0, avg: 23.61, max: 259.58}
     - PM10: {min: 4.5, avg: 11.38, max:  54.86}
     - PM25: {min: 2.4, avg:  6.83, max:  33.54}
 
-After that, we can run Caline4
+The units are micro gram per cubic centimeter. After that, we can run Caline 4.0 using
 
     python run/run_caline_model.py
 
-Please check within the header for adjustable parameters. You may want to run the Caline model with a variety of settings before pre-process the estimates and train the machine learning model. This generates a denser data set. 
+Please check within the header of the file for adjustable parameters. 
 
-The receptor positions 
-are determined randomly for each new run. For the publication, runs have been carried out with receptors at distances of 
-6, 12, 18, 20, 24, 26, 30, 33, 40, 52, 60, 66, 78, 80, 99, 
-100, 104, 105, 125, 130, 132, 160, 165, 210, 250, 315, 320, 375, 420, 480, 500, 
-525, 600, 625, 640, 800, 750, 1200, 1500, 1800, 2250, 2400, and 3000 
-meters away from the line sources.
+This script estimates the traffic-induced air pollution levels of NO2, PM2.5, and PM10 for 
+defined receptors across the domain. The prediction framework consisted of an air-pollution 
+dispersion model, inputs of traffic volumes for a number of roadway links across the city, 
+and weather data. Outputs consist of periodic estimates of pollution levels. The PDE-based model 
+used is based on the Gaussian Plume model, a standard model in describing the steady-state 
+transport of pollutants. Caline 4 implements the Gaussian Plume model and is one of the 
+“Preferred and Recommended Air Quality Dispersion Models” of the Environmental Protection Agency 
+in the USA as of 2018.
+    
+The input to the Caline model on each sub-domain consists of:
+
+- (normalized) coordinates of 20 line sources, padded with zeros if fewer sources are in the partition;
+- integrated traffic volumes over one hour for each source, padded with zeros;
+- the average wind direction, the standard deviation of wind direction, the wind speed, and the temperature in this hour;
+- model specific parameters, such as atmospheric stability standard, emission factor, 
+  aerodynamic roughness coefficient standard, settling velocity standard, disposition 
+  velocity standard, and mixing zone dimensions;
+- (normalized) coordinates of 20 receptors.
+
+The output consists of:
+- Average NO2, PM2.5, and PM10 concentrations at the receptors in ㎍/cm3 for that hour. 
+
+Caline 4 is limited to 20 line sources and 20 receptors per computational run. The bigger domains of Dublin and the demo have been decomposed into sub-domains with a maximum of 20 line sources. See 
+`util.util_domain_decomposition.decompose_domain` for more info on the decomposition. 
+The receptors are placed at random positions, but in intervals at certain distances to the line 
+sources, based on the `contour_distance` in the parameter initialization. See 
+`util.util_domain_decomposition.get_receptors` for more info on their placement.
+
+The Caline estimates are very low for low traffic volumes and are in a regime of low numerical 
+resolution. We therefore scale the traffic volumes by a `scaling_factor` and divide the 
+pollution concentration outputs by it. Schematically,
+
+    Caline(traffic, background) = Caline(scaling_factor * traffic, 
+                                         scaling_factor * background) / scaling_factor
+                                         
+This assumes a linear dependence, which we could empirically confirm to good approximation. In any case, for this project, we are only interested in using this PDE solver as a generator for ground truth data, so the physical accuracy of this step is of no major concern.
+
+Caline is only modeling the contribution to the pollution levels coming from traffic and weather influence. Thus, we remove the default background pollution from the output again.
+
+    output = Caline(traffic, weather, default background) - default background
 
 A benchmark for one run to estimate pollution levels using Caline (under Windows):
         
@@ -96,28 +146,35 @@ A benchmark for one run to estimate pollution levels using Caline (under Windows
         Average Caline run time for each tile, hour and pollutant: 0.05s
         Standard Deviation: 0.01s
 
-The Caline script, as well as the pre-processing, and the ML model scripts have headers with user-adjustable parameters.
+The Caline script has a header with user-adjustable parameters.
+
+You may want to run the Caline model with a variety of settings before pre-processing the estimates and train the machine learning model. Doing so generates a denser data set. 
+
+The receptor positions are determined randomly for each new run. For the publication, runs have been carried out with receptors at distances of multiples of
+`6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750`
+meters away from the line sources for the Dublin data, and `5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103` for the demo.
+
+
+### From the Database
+
+The supplemented database contains all generated data up to this point. Next up is the pre-processing for the training of the ML model. This involves rescaling all different input units to lie within the same order of magnitude. Check the headers of the files for user-adjustable parameters.
 
     python run/run_pre_processing.py
+
+Now we can run the deep learning model.
+
     python run/run_ml_model.py
 
-The last remaining step is to evaluate and plot the data.
+The last remaining step is to evaluate the data.
 
     python plotting/run_evaluation.py
         
-If of interest, the weather and traffic data, and the Caline estimates can be plotted too:
+If of interest, many things can be plotted:
 
-    python plotting/plot_weather_data.py
+    python plotting/plot_maps.py
     python plotting/plot_traffic_volumes.py
-    python plotting/plot_pollution_estimates.py
+    python plotting/plot_weather_data.py
 
 Check the header of each file for more detail. 
 
-Work in progress: more plotting functions are in `PollutionModelling/plotting/paper_plots.py`
-
-
-
-## package `unit_tests`
-- This package contains (a few) tests for the database connection and utility functions. Run it from the console from the root of the repository:
-    
-      python -m pytest unit_tests/
+Thank you for your interest in this project! Don't hesitate to contact us if you have any questions, concerns, or comments. 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,20 @@ The supplemented database contains all generated data up to this point. Next up 
 
     python run/run_pre_processing.py
 
+Within the user-chosen parameters, you can select the tags for identifying the Caline data in the collection, which has the identifiers
+
+    'run_tag': (str) anything, but we used the date of the run in format 'YYYY-MM-DD' 
+    'case': (str) 'Dublin' or 'Demo'
+    'contour_distance': (int) interval distance for placing receptors from line sources
+
+From the collection, different pre-processing runs are identified via the ‘case’ (Dublin or Demo, as given in the get_parameters() L.99), and 'mesh_size', which is the length of the sub domain selection in L.86. So, it would be possible to have a couple of pre-processed data together without creating and managing new collections: 
+
+1) the Demo
+2) the full Dublin example
+3) some subset of the Dublin example, restricted to a number of tiles
+
+Make sure that there is no other data in the pre_proc collection!
+
 Now we can run the deep learning model.
 
     python run/run_ml_model.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deep Learning for PDE-based Models
 
-Consider a complex non-linear forecasting problem, e.g. from weather- and air pollution data. A general issue with those problems is that forecasting methods based on solving partial differential equations (PDEs) require a lot of computing power in the model-application phase, especially for applications to large domains, where domain decomposition methods are applied. An idea to circumvent this issue is to use deep-learning techniques to reduce the run-time of the model-application phase at a cost of increasing the run-time of the model-training phase. In this project, we propose domain decomposition methods to scale the deep-learning model to larger domains by imposing consistency constraints during the training across sub-domain boundaries. We demonstrate the methods at the example of an air pollution forecasting problem, which is governed by an advection-diffusion process and described through a PDE.
+Consider a complex non-linear forecasting problem, e.g. from weather- and air pollution data. A general issue with those problems is that forecasting methods based on solving partial differential equations (PDEs) require a lot of computing power in the model-application phase, especially for applications to large domains, where domain decomposition methods are applied. An idea to circumvent this issue is to use deep-learning techniques to reduce the run-time of the model-application phase at a cost of increasing the run-time of the model-training phase. In this project, we propose domain decomposition methods to scale the deep-learning model to larger domains by imposing consistency constraints during the training across sub-domain boundaries. We demonstrate the methods at the example of an air pollution forecasting problem, which is governed by an advection-diffusion process and described through a PDE.
 
 If you use the code, please also cite our paper: https://arxiv.org/abs/1810.09425
 
@@ -177,4 +177,7 @@ If of interest, many things can be plotted:
 
 Check the header of each file for more detail. 
 
-Thank you for your interest in this project! Don't hesitate to contact us if you have any questions, concerns, or comments. 
+
+## Thank you!
+
+Thank you for your interest in this project! Don't hesitate to contact us if you have any questions, comments, or concerns. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you use the code, please also cite our paper: https://arxiv.org/abs/1810.0942
 
 The databases are currently not supplemented since they are proprietary. We are working on providing artificially generated replacements. 
 
-Any questions can be directed to Philipp Hähnel, `phahnel@hsph.harvard.edu`.
+Any questions can be directed to Philipp Hähnel, `phahnel [at] hsph.harvard.edu`.
 
 
 

--- a/plotting/plot_contour_maps.py
+++ b/plotting/plot_contour_maps.py
@@ -1,0 +1,260 @@
+from collections import defaultdict
+import datetime
+
+from matplotlib.colors import Normalize
+#  This runs into an issue under Mac OS X, thus the workaround.
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import matplotlib
+    matplotlib.use('PS')
+    from matplotlib import pyplot as plt
+
+import numpy as np
+import pymongo
+import scipy as sp
+from scipy.interpolate import griddata
+
+import util.util_db_access as uda
+
+
+""" 
+
+-*- coding: utf-8 -*-
+
+Legal:
+    (C) Copyright IBM 2018.
+
+    This code is licensed under the Apache License, Version 2.0. You may
+    obtain a copy of this license in the LICENSE.txt file in the root 
+    directory of this source tree or at 
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Any modifications or derivative works of this code must retain this
+    copyright notice, and modified files need to carry a notice 
+    indicating that they have been altered from the originals.
+
+    IBM-Review-Requirement: Art30.3
+    Please note that the following code was developed for the project 
+    VaVeL at IBM Research -- Ireland, funded by the European Union under 
+    the Horizon 2020 Program.
+    The project started on December 1st, 2015 and was completed by 
+    December 1st, 2018. Thus, in accordance with Article 30.3 of the 
+    Multi-Beneficiary General Model Grant Agreement of the Program, 
+    there are certain limitations in force  up to December 1st, 2022. 
+    For further details please contact Jakub Marecek 
+    (jakub.marecek@ie.ibm.com) or Gal Weiss (wgal@ie.ibm.com).
+
+If you use the code, please cite our paper:
+https://arxiv.org/abs/1810.09425
+
+Authors: 
+    Philipp Hähnel <phahnel@hsph.harvard.edu>
+
+Last updated:
+    2019 - 08 - 30
+
+"""
+
+
+def get_parameters():
+    """
+    :return:
+    """
+    #  time slice (2017-07-01 01:00:00 to 2018-05-02 14:00:00)
+    param = {
+        'case': 'Demo',
+        'date_start': datetime.datetime(2017, 10, 22, 0),
+        'date_end': datetime.datetime(2017, 10, 23, 0),
+        'iteration': 1,
+        'pollutants': ['NO2'],
+        'resolution': 150,
+    }
+    return param
+
+
+class MidpointNormalize(Normalize):
+    """ from https://matplotlib.org/users/colormapnorms.html """
+    def __init__(self, vmin, vmax, midpoint=0, clip=False):
+        self.midpoint = midpoint
+        super().__init__(vmin, vmax, clip)
+
+    def __call__(self, value, clip=None):
+        normalized_min = max(
+            0,
+            1 / 2 * (1 - abs((self.midpoint - self.vmin)
+                             / (self.midpoint - self.vmax)))
+        )
+        normalized_max = min(
+            1,
+            1 / 2 * (1 + abs((self.vmax - self.midpoint)
+                             / (self.midpoint - self.vmin)))
+        )
+        normalized_mid = 0.5
+        x = [self.vmin, self.midpoint, self.vmax]
+        y = [normalized_min, normalized_mid, normalized_max]
+        return sp.ma.masked_array(sp.interp(value, x, y))
+
+
+def plot_heatmap(date, **kwargs):
+    print('Getting Caline estimates ...')
+    caline_estimates, receptor_list = uda.get_estimates(
+        collection_estimates=collection_caline_estimates,
+        date_start=date,
+        date_end=date,
+        case=kwargs['case']
+    )
+    caline_data = defaultdict(list)
+    caline_dict = defaultdict(dict)  # just for convenience
+    # turn {timestamp: {coord: {pollutant: value}}}
+    # into {pollutant: [coord.x, coord.y, value]}
+    for _, receptor_values in caline_estimates.items():
+        for coord, pollution_values in receptor_values.items():
+            for pollutant, value in pollution_values.items():
+                caline_data[pollutant].append(list(coord) + [value])
+                caline_dict[pollutant][coord] = value
+
+    print('Getting MLP estimates ...')
+    ml_filter = {
+        'iteration': kwargs['iteration']
+        # 'settings.gamma': gamma,
+        # 'settings.kappa': kappa,
+        # 'settings': iter
+    }
+    ml_estimates, receptor_list = uda.get_estimates(
+        collection_estimates=collection_estim,
+        date_start=date,
+        date_end=date,
+        **ml_filter
+    )
+    ml_data = defaultdict(list)
+    diff = defaultdict(list)
+    # turn {timestamp: {coord: {pollutant: value}}}
+    # into {pollutant: [coord.x, coord.y, value]}
+    for _, receptor_values in ml_estimates.items():
+        for coord, pollution_values in receptor_values.items():
+            for pollutant, value in pollution_values.items():
+                ml_data[pollutant].append(list(coord) + [value])
+                diff[pollutant].append(
+                    list(coord) + [caline_dict[pollutant][coord] - value]
+                )
+
+    print('Plotting heatmap ...')
+    for p, poll in enumerate(kwargs['pollutants']):
+
+        xi, yi, zi = [], [], []
+        ml_xi, ml_yi, ml_zi = [], [], []
+        d_xi, d_yi, d_zi = [], [], []
+
+        if poll in caline_data:
+            [y, x, z] = np.transpose(caline_data[poll])
+            xi = np.linspace(min(x), max(x), kwargs['resolution'])
+            yi = np.linspace(min(y), max(y), kwargs['resolution'])
+            zi = griddata((x, y), z,
+                          (xi[None, :], yi[:, None]),
+                          method='nearest')
+        if poll in ml_data:
+            [ml_y, ml_x, ml_z] = np.transpose(ml_data[poll])
+            ml_xi = np.linspace(min(ml_x), max(ml_x), kwargs['resolution'])
+            ml_yi = np.linspace(min(ml_y), max(ml_y), kwargs['resolution'])
+            ml_zi = griddata((ml_x, ml_y), ml_z,
+                             (ml_xi[None, :], ml_yi[:, None]),
+                             method='nearest')
+        if poll in diff:
+            [d_y, d_x, d_z] = np.transpose(diff[poll])
+            d_xi = np.linspace(min(d_x), max(d_x), kwargs['resolution'])
+            d_yi = np.linspace(min(d_y), max(d_y), kwargs['resolution'])
+            d_zi = griddata((d_x, d_y), d_z,
+                            (d_xi[None, :], d_yi[:, None]),
+                            method='nearest')
+
+        # Layout of the plot:
+        #
+        # Caline estimates. differences
+        # position map    . ML estimates
+
+        fig = plt.figure(figsize=(15, 10))
+        st = plt.suptitle(
+            'Pollution estimates for ' + kwargs['case'] + ' for ' + str(date)
+            + '\n'
+            + poll + ' concentration levels in [micrograms/m3]',
+            fontsize='x-large'
+        )
+
+        sub1 = fig.add_subplot(2, 2, 1)
+        sub1.set_title('Caline estimates')
+        plt.contour(xi, yi, zi, 10, linewidths=0.5, colors='k')
+        plt.contourf(xi, yi, zi, 15, cmap='YlOrRd')
+        plt.colorbar()
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+
+        sub2 = fig.add_subplot(2, 2, 2)
+        sub2.set_title('Differences between Caline and ML estimates')
+        plt.contour(d_xi, d_yi, d_zi, 10, linewidths=0.5, colors='k')
+        plt.contourf(d_xi, d_yi, d_zi, 15,
+                     cmap='seismic',
+                     norm=MidpointNormalize(
+                         vmin=np.min(d_zi),
+                         vmax=np.max(d_zi),
+                         midpoint=0
+                     ))
+        plt.colorbar()
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+
+        # sub3 = fig.add_subplot(2, 2, 3)
+        # plot_receptor_map()
+
+        sub4 = fig.add_subplot(2, 2, 4)
+        sub4.set_title('ML estimates after ' + str(kwargs['iteration'])
+                       + ' iteration(s)')
+        plt.contour(ml_xi, ml_yi, ml_zi, 10, linewidths=0.5, colors='k')
+        plt.contourf(ml_xi, ml_yi, ml_zi, 15, cmap='YlOrRd')
+        plt.colorbar()
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+
+        # shift subplots down:
+        st.set_y(0.95)
+        fig.subplots_adjust(top=0.85, hspace=0.3)
+
+        plt.savefig(
+            img_path + 'contour_maps/' + poll + '/'
+            + kwargs['case']
+            + '_' + str(kwargs['iteration'])
+            + '_' + date.strftime('%Y-%m-%d_%H')
+            + '.pdf'
+        )
+        plt.close()
+
+    return None
+
+
+if __name__ == '__main__':
+
+    benchmark_path = '../output/benchmarks/'
+    img_path = '../output/img/'
+
+    """ connect to internal Mongo database """
+    client = pymongo.MongoClient('localhost', 27018)
+    # 2017-07-01 01:00:00 to 2018-05-02 14:00:00
+    collection_measurement = client.db_air_quality.pollution_measurements
+    collection_caline_estimates = client.db_air_quality.caline_estimates
+    collection_estim = client.db_air_quality.ml_estimates
+    collection_util = client.db_air_quality.util
+
+    parameters = get_parameters()
+
+    date_start = parameters['date_start']
+    date_end = parameters['date_end']
+    time_step = datetime.timedelta(hours=1)
+
+    current = date_start
+
+    while current <= date_end:
+        plot_heatmap(
+            date=current,
+            **parameters
+        )
+        current += time_step

--- a/plotting/plot_maps.py
+++ b/plotting/plot_maps.py
@@ -47,7 +47,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 07 - 05
+    2019 - 08 - 02
 
 """
 

--- a/plotting/plot_maps.py
+++ b/plotting/plot_maps.py
@@ -11,7 +11,6 @@ import pymongo
 import util.util_db_access as uda
 import util.util_measurements as um
 
-
 """ Script to plot coordinate maps of traffic links, domain boundaries, 
     receptors, and measurement stations.  
 
@@ -75,11 +74,13 @@ def get_parameters():
     distances = [
         6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
     ]  # Dublin
-    param['tags'] = [{'run_tag': '2019-07-04',
-                      'contour_distance': dist,
-                      'case': 'Dublin'  # 'Demo' or 'Dublin'
-                      }
-                     for dist in distances]
+    param['tags'] = [{
+            'run_tag': '2019-07-04',
+            'contour_distance': dist,
+            'case': 'Dublin'  # 'Demo' or 'Dublin'
+        }
+        for dist in distances
+    ]
     # Title of each plot. If plots are combined, only the last title is used.
     param['titles'] = {dist: f'Map of Dublin.'
                        for dist in distances}

--- a/plotting/plot_maps.py
+++ b/plotting/plot_maps.py
@@ -46,7 +46,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 02
+    2019 - 08 - 30
 
 """
 
@@ -68,16 +68,22 @@ def get_parameters():
         'comment': ''
     }
     # runs selectors from the caline_estimates
-    # distances = [
-    #     5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103
-    # ]  # Demo
-    distances = [
-        6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
-    ]  # Dublin
+    case = 'Demo'  # 'Demo' or 'Dublin'
+    if case == 'Demo':
+        distances = [
+            5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103
+        ]
+    elif case == 'Dublin':
+        distances = [
+            6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
+        ]
+    else:
+        distances = []
+
     param['tags'] = [{
             'run_tag': '2019-07-04',
             'contour_distance': dist,
-            'case': 'Dublin'  # 'Demo' or 'Dublin'
+            'case': case
         }
         for dist in distances
     ]

--- a/plotting/plot_maps.py
+++ b/plotting/plot_maps.py
@@ -1,0 +1,157 @@
+#  This runs into an issue under Mac OS X, thus the workaround.
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import matplotlib
+    matplotlib.use('PS')
+    from matplotlib import pyplot as plt
+
+import pymongo
+
+import util.util_db_access as uda
+import util.util_measurements as um
+
+
+""" Script to plot coordinate maps of traffic links, domain boundaries, 
+    receptors, and measurement stations.  
+
+-*- coding: utf-8 -*-
+
+Legal:
+    (C) Copyright IBM 2018.
+
+    This code is licensed under the Apache License, Version 2.0. You may
+    obtain a copy of this license in the LICENSE.txt file in the root 
+    directory of this source tree or at 
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Any modifications or derivative works of this code must retain this
+    copyright notice, and modified files need to carry a notice 
+    indicating that they have been altered from the originals.
+
+    IBM-Review-Requirement: Art30.3
+    Please note that the following code was developed for the project 
+    VaVeL at IBM Research -- Ireland, funded by the European Union under 
+    the Horizon 2020 Program.
+    The project started on December 1st, 2015 and was completed by 
+    December 1st, 2018. Thus, in accordance with Article 30.3 of the 
+    Multi-Beneficiary General Model Grant Agreement of the Program, 
+    there are certain limitations in force  up to December 1st, 2022. 
+    For further details please contact Jakub Marecek 
+    (jakub.marecek@ie.ibm.com) or Gal Weiss (wgal@ie.ibm.com).
+
+If you use the code, please cite our paper:
+https://arxiv.org/abs/1810.09425
+
+Authors: 
+    Philipp Hähnel <phahnel@hsph.harvard.edu>
+
+Last updated:
+    2019 - 07 - 05
+
+"""
+
+
+def get_parameters():
+    """
+    :return:
+    """
+    #  time slice (2017-07-01 01:00:00 to 2018-05-02 14:00:00)
+    param = {
+        # list of ID's of tiles to be plotted:
+        'sub_domain_selection': list(range(1, 12 + 1)),
+        # 'sub_domain_selection': [6, 7],
+        # if stations are plotted:
+        'with_stations': True,
+        # plot each of the runs in 'tags' individually or combined:
+        'individual': False,
+        # is appended to file name:
+        'comment': ''
+    }
+    # runs selectors from the caline_estimates
+    # distances = [
+    #     5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103
+    # ]  # Demo
+    distances = [
+        6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
+    ]  # Dublin
+    param['tags'] = [{'run_tag': '2019-07-04',
+                      'contour_distance': dist,
+                      'case': 'Dublin'  # 'Demo' or 'Dublin'
+                      }
+                     for dist in distances]
+    # Title of each plot. If plots are combined, only the last title is used.
+    param['titles'] = {dist: f'Map of Dublin.'
+                       for dist in distances}
+    return param
+
+
+def plot_map(collection_util, stations, img_path='../output/img/', **kwargs):
+    print(f'Plotting receptor map. Output in {img_path}')
+    for tag in kwargs['tags']:
+        util = uda.get_utilities_from_collection(collection_util, **tag)
+        station_list = [point for point in stations.values()]
+        borders = []
+        for tile, ngbrs in util["intersections"].items():
+            if tile in kwargs['sub_domain_selection']:
+                for ngbr, border in ngbrs.items():
+                    borders.append(border)
+        print('Plotting map for current utilities.')
+        handle_b = None
+        handle_r = None
+        handle_s = None
+        handle_t = None
+        # plot mesh grid
+        for line in borders:
+            y = [line[0][0], line[1][0]]
+            x = [line[0][1], line[1][1]]
+            handle_b, = plt.plot(x, y, c='k')
+        for box_id in util["emitters_dict"]:
+            if box_id in kwargs['sub_domain_selection']:
+                data_e = util["emitters_dict"][box_id]
+                data_r = util["receptors_dict"][box_id] \
+                    if box_id in util["receptors_dict"] else []
+                # plot line sources
+                for line in data_e:
+                    y = [line[0], line[2]]
+                    x = [line[1], line[3]]
+                    handle_t, = plt.plot(x, y, c='b')
+                # plot receptors
+                for point in data_r:
+                    y = point[0]
+                    x = point[1]
+                    handle_r = plt.scatter(x, y, c='r', marker='.')
+        # plot measurement stations
+        for point in station_list:
+            y = point[0]
+            x = point[1]
+            handle_s = plt.scatter(x, y, c='g', marker='D')
+
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+        plt.title(kwargs['titles'][tag['contour_distance']])
+        handles = [handle_b, handle_t, handle_r, handle_s] \
+            if station_list else [handle_b, handle_t, handle_r]
+        plt.legend(handles, ['domain border', 'street', 'receptor', 'station'])
+        name = img_path + 'maps/discretization_' + str(tag) + kwargs['comment']
+        if kwargs['individual']:
+            plt.savefig(name + '.pdf')
+            # plt.savefig(name + '.png')
+            plt.close()
+    if not kwargs['individual']:
+        name = img_path + 'maps/discretization_' + kwargs['tags'][0]['case']
+        if kwargs['comment']:
+            name += '_' + kwargs['comment']
+        plt.savefig(name + '.pdf')
+
+    return None
+
+
+if __name__ == '__main__':
+    """ connect to internal Mongo database """
+    client = pymongo.MongoClient('localhost', 27018)
+    # 2017-07-01 01:00:00 to 2018-05-02 14:00:00
+    collection_util = client.db_air_quality.util
+    param = get_parameters()
+    stations = um.get_stations() if param['with_stations'] else {}
+    plot_map(collection_util=collection_util, stations=stations, **param)

--- a/plotting/plot_timeseries.py
+++ b/plotting/plot_timeseries.py
@@ -1,0 +1,214 @@
+from collections import defaultdict
+import datetime
+
+#  This runs into an issue under Mac OS X, thus the workaround.
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import matplotlib
+    matplotlib.use('PS')
+    from matplotlib import pyplot as plt
+
+import numpy as np
+import pymongo
+
+import util.util_db_access as uda
+
+
+""" 
+
+-*- coding: utf-8 -*-
+
+Legal:
+    (C) Copyright IBM 2018.
+
+    This code is licensed under the Apache License, Version 2.0. You may
+    obtain a copy of this license in the LICENSE.txt file in the root 
+    directory of this source tree or at 
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Any modifications or derivative works of this code must retain this
+    copyright notice, and modified files need to carry a notice 
+    indicating that they have been altered from the originals.
+
+    IBM-Review-Requirement: Art30.3
+    Please note that the following code was developed for the project 
+    VaVeL at IBM Research -- Ireland, funded by the European Union under 
+    the Horizon 2020 Program.
+    The project started on December 1st, 2015 and was completed by 
+    December 1st, 2018. Thus, in accordance with Article 30.3 of the 
+    Multi-Beneficiary General Model Grant Agreement of the Program, 
+    there are certain limitations in force  up to December 1st, 2022. 
+    For further details please contact Jakub Marecek 
+    (jakub.marecek@ie.ibm.com) or Gal Weiss (wgal@ie.ibm.com).
+
+If you use the code, please cite our paper:
+https://arxiv.org/abs/1810.09425
+
+Authors: 
+    Philipp Hähnel <phahnel@hsph.harvard.edu>
+
+Last updated:
+    2019 - 08 - 02
+
+"""
+
+
+def get_parameters():
+    """
+    :return:
+    """
+    #  time slice (2017-07-01 01:00:00 to 2018-05-02 14:00:00)
+    param = {
+        'date_start': datetime.datetime(2017, 11, 19, 0),
+        'period': datetime.timedelta(days=3),
+        'receptor_coord': [53.34421064496467, -6.26476486860426],
+        'station_name': 'Winetavern St Civic Offices',
+        # is appended to file name:
+        'pollutants': ['NO2']
+    }
+    return param
+
+
+def plot_timeseries(
+        date_start, period, receptor_coord, station_name, pollutants,
+        # gamma=1, kappa=0.5, iter=2, seed=1753245344
+        **kwargs
+):
+
+    timestamp_start = date_start.timestamp()
+    # there is a mismatch between dates and labels
+    date_print = date_start - datetime.timedelta(hours=16)
+    date_end = date_start + period
+    site = tuple(receptor_coord)
+
+    print('Getting station measurement data ...')
+    station_measurements = uda.get_station_measurements(
+        collection_measurements=collection_measurement,
+        date_start=date_start,
+        date_end=date_end,
+        station_name=station_name
+    )
+    station_time_series = defaultdict(list)
+    polls = []
+    for timestamp, pollution_values in station_measurements.items():
+        for pollutant, value in pollution_values.items():
+            t = timestamp - timestamp_start
+            if pollutant not in polls:
+                polls.append(pollutant)
+            station_time_series[pollutant].append((t, value))
+
+    print('Getting background pollution data ...')
+    background_pollution = uda.get_background_pollution(
+        collection_measurements=collection_measurement,
+        date_start=date_start,
+        date_end=date_end
+    )
+    background_time_series = defaultdict(list)
+    for timestamp, pollution_values in background_pollution.items():
+        for pollutant, value in pollution_values.items():
+            t = timestamp - timestamp_start
+            background_time_series[pollutant].append((t, value))
+
+    print('Getting Caline estimates ...')
+    caline_estimates = uda.get_caline_estimates_for_receptor(
+        collection_caline_estimates=collection_caline_estimates,
+        date_start=date_start,
+        date_end=date_end,
+        receptor_coord=receptor_coord
+    )
+    caline_time_series = defaultdict(list)
+    timestamps = []
+    for timestamp, pollution_values in caline_estimates.items():
+        for pollutant, value in pollution_values.items():
+            t = timestamp - timestamp_start
+            if t not in timestamps:
+                timestamps.append(t)
+            caline_time_series[pollutant].append((t, value))
+
+    print('Getting MLP estimates ...')
+    ml_filter = {
+        # 'settings.gamma': gamma,
+        # 'settings.kappa': kappa,
+        # 'settings.iteration': iter
+    }
+    ml_estimates = uda.get_ml_estimates_for_receptor(
+        collection_ml_estimates=collection_estim,
+        collection_util=collection_util,
+        date_start=date_start,
+        date_end=date_end,
+        receptor_coord=receptor_coord,
+        **ml_filter
+    )
+    ml_time_series = defaultdict(list)
+    for timestamp, pollution_values in ml_estimates.items():
+        for pollutant, value in pollution_values.items():
+            t = timestamp - timestamp_start
+            ml_time_series[pollutant].append((t, value))
+
+    # mlp_labels = np.asarray(list(reversed([label[(index-1)*3] for label in entry['labels']])))
+
+    timestamps.sort()
+
+    print('Plotting time series ...')
+    for p, poll in enumerate(pollutants):
+        fig = plt.figure(figsize=(10, 10))
+        sub = fig.add_subplot(1, 1, 1)
+
+        [station_x, station_y] = np.transpose(station_time_series[poll])
+        station, = plt.plot(station_x, station_y, 'b.',
+                            label='station measurements')
+        handles = [station]
+
+        [bgrd_x, bgrd_y] = np.transpose(background_time_series[poll])
+
+        if poll in caline_time_series:
+            [x, y] = np.transpose(caline_time_series[poll])
+            y += bgrd_y
+            caline, = plt.plot(x, y, 'r+', label='Caline estimates')
+            handles.append(caline)
+
+        if poll in ml_time_series:
+            [ml_x, ml_y] = np.transpose(ml_time_series[poll])
+            ml_y += bgrd_y
+            mlp, = plt.plot(ml_x, ml_y, 'gx', label='MLP estimates')
+            handles.append(mlp)
+
+        loc_x = list(np.linspace(x.min(), x.max(), 4))
+        label_x = list(range(0, 4*24, 24))
+        plt.xticks(loc_x, label_x)
+        sub.set_xticks(x, minor=True)
+        label_y = list(range(0, 81, 10))
+        plt.yticks(label_y, label_y)
+        sub.grid(which='major')
+
+        plt.xlabel('Hours from ' + date_print.strftime('%Y-%m-%d %H:%M:%S'))
+        plt.ylabel(poll + ' concentration [micrograms/m3]')
+        plt.title('Pollution Data in Dublin City Center '
+                  '(near ' + str(receptor_coord) + ')')
+        plt.legend(handles=handles)
+        plot_name = (
+            img_path + 'timeseries/timeseries_' + poll + '_'
+            + str(site) + '_' + date_start.strftime('%Y-%m-%d_%H-%M-%S')
+        )
+        plt.savefig(plot_name + '.pdf')
+        # plt.savefig(plot_name + '.png')
+        plt.close()
+
+    return None
+
+
+if __name__ == '__main__':
+
+    benchmark_path = '../output/benchmarks/'
+    img_path = '../output/img/'
+
+    """ connect to internal Mongo database """
+    client = pymongo.MongoClient('localhost', 27018)
+    # 2017-07-01 01:00:00 to 2018-05-02 14:00:00
+    collection_measurement = client.db_air_quality.pollution_measurements
+    collection_caline_estimates = client.db_air_quality.caline_estimates
+    collection_estim = client.db_air_quality.ml_estimates
+    collection_util = client.db_air_quality.util
+
+    plot_timeseries(**get_parameters())

--- a/plotting/plot_traffic_volumes.py
+++ b/plotting/plot_traffic_volumes.py
@@ -14,6 +14,7 @@ except ImportError:
 
 from util import util_db_access as uda
 
+
 """ Script for plotting the traffic data.
 
     This module plots aggregated traffic data from the collection 
@@ -56,6 +57,7 @@ Last updated:
 
 """
 
+
 ###################
 # Parameters to change
 #
@@ -68,8 +70,6 @@ timestamp_start = datetime.datetime.strptime(
     '2017-07-01 00:00:00', '%Y-%m-%d %H:%M:%S').timestamp()
 
 figure_size = (35, 5)
-
-
 #
 #
 ###################

--- a/plotting/plot_traffic_volumes.py
+++ b/plotting/plot_traffic_volumes.py
@@ -1,0 +1,180 @@
+import datetime
+import numpy as np
+import pymongo
+import sys
+
+#  This runs into an issue under Mac OS X, thus the workaround.
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import matplotlib
+
+    matplotlib.use('PS')
+    from matplotlib import pyplot as plt
+
+from util import util_db_access as uda
+
+""" Script for plotting the traffic data.
+
+    This module plots aggregated traffic data from the collection 
+    'traffic_volumes' of a MongoDB database called 'db_air_pollution' 
+    at port 27018. It writes plots into the relative img_path path.
+
+-*- coding: utf-8 -*-
+
+Legal:
+    (C) Copyright IBM 2018.
+
+    This code is licensed under the Apache License, Version 2.0. You may
+    obtain a copy of this license in the LICENSE.txt file in the root 
+    directory of this source tree or at 
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Any modifications or derivative works of this code must retain this
+    copyright notice, and modified files need to carry a notice 
+    indicating that they have been altered from the originals.
+
+    IBM-Review-Requirement: Art30.3
+    Please note that the following code was developed for the project 
+    VaVeL at IBM Research -- Ireland, funded by the European Union under 
+    the Horizon 2020 Program.
+    The project started on December 1st, 2015 and was completed by 
+    December 1st, 2018. Thus, in accordance with Article 30.3 of the 
+    Multi-Beneficiary General Model Grant Agreement of the Program, 
+    there are certain limitations in force  up to December 1st, 2022. 
+    For further details please contact Jakub Marecek 
+    (jakub.marecek@ie.ibm.com) or Gal Weiss (wgal@ie.ibm.com).
+
+If you use the code, please cite our paper:
+https://arxiv.org/abs/1810.09425
+
+Authors: 
+    Philipp Hähnel <phahnel@hsph.harvard.edu>
+
+Last updated:
+    2019 - 08 - 02
+
+"""
+
+###################
+# Parameters to change
+#
+img_path = '../output/img/traffic/'
+
+# 2017-07-01 01:00:00 to 2018-05-02 14:00:00
+date_start = datetime.datetime(2017, 7, 1, 0)
+date_end = datetime.datetime(2018, 5, 2, 23)
+timestamp_start = datetime.datetime.strptime(
+    '2017-07-01 00:00:00', '%Y-%m-%d %H:%M:%S').timestamp()
+
+figure_size = (35, 5)
+
+
+#
+#
+###################
+
+
+def get_traffic_data(collection, domain_dict):
+    """
+        Retrieve list of link sources as a dictionary from database.
+        It's a rearranged output of util.util_caline.get_traffic_volumes()
+    :param collection: db_air_quality.traffic_volumes
+    :param box_dict: from db_air_quality.util
+    :return: link_time_series = {link: {timestamp: volume}}
+    """
+    traffic_links = [
+        sorted(link)
+        for box in domain_dict.values()
+        for link in box['links']
+    ]
+    traffic_volumes = uda.get_traffic_volumes(
+        collection, date_start, date_end, traffic_links
+    )
+    link_time_series = {}
+    for timestamp, link_volumes in traffic_volumes.items():
+        for link, volume in link_volumes.items():
+            if link not in link_time_series:
+                link_time_series[link] = {}
+            link_time_series[link][timestamp] = volume
+    return link_time_series
+
+
+def plot_traffic(time_series, link):
+    """
+        Plots the time_series data
+    :param time_series: {timestamp: volume}
+    :param link: int
+    :return: None
+    """
+    x = np.array([float(i) - timestamp_start for i in time_series.keys()])
+    y = np.array([float(i) for i in time_series.values()])
+
+    fig = plt.figure(figsize=figure_size)
+    sub = fig.add_subplot(1, 1, 1)
+    line_up, = plt.plot(x, y, label='traffic data at link ' + str(link))
+    # num = max(1, int((x.max() - x.min()) / (60 * 60 * 24 * 7)))
+    loc_x = np.linspace(x.min(), x.max(),
+                        max(1, int((x.max() - x.min())
+                                   / (60 * 60 * 24 * 7))
+                            )
+                        )
+    # loc_x = list(range(int(x.min()), int(x.max()),
+    #                    max(1, int((x.max() - x.min())
+    #                               / (60 * 60 * 24 * 7))
+    #                        )
+    #                    ))
+    label_x = list(range(int((x.max() - x.min()) / (60 * 60 * 24 * 7))))
+    plt.xticks(loc_x, label_x)
+    # sub.set_xticks(x, minor=True)
+    label_y = list(np.linspace(y.min(), y.max(), 10))
+    # label_y = list(range(int(y.min()), int(y.max()),
+    #                      max(1, int((y.max() - y.min()) / 5))))
+    if len(label_y) < 5:
+        label_y = list(set(y))
+    plt.yticks(label_y, label_y)
+    sub.grid(which='major')
+    plt.xlabel('Weeks from 2017-07-01')
+    plt.ylabel('vehicle count')
+    plt.legend(handles=[line_up])
+    plt.savefig(img_path + 'traffic_volumes_' + str(link) + '.pdf')
+    plt.close()
+
+    return None
+
+
+def main():
+    """
+        Connect to database, retrieve traffic data and plot for all
+        available roads.
+
+    :return: None
+    """
+    """ connect to internal Mongo database """
+    client = pymongo.MongoClient('localhost', 27018)
+    # 2017-07-01 01:00:00 to 2018-05-02 14:00:00
+    collection_traffic_volumes = client.db_air_quality.traffic_volumes
+    collection_util = client.db_air_quality.util
+
+    util = collection_util.find({})
+
+    if util.count():
+        entry = util[0]
+        domain_dict = {k: v for k, v in entry['domain_dict']}
+    else:
+        print('Update utility DB!')
+        sys.exit()
+
+    print('getting traffic data ...')
+    link_time_series = get_traffic_data(collection_traffic_volumes,
+                                        domain_dict)
+
+    print('plotting traffic data ...')
+    for link, time_series in link_time_series.items():
+        plot_traffic(time_series, link)
+
+    return None
+
+
+if __name__ == '__main__':
+    main()

--- a/plotting/plot_traffic_volumes.py
+++ b/plotting/plot_traffic_volumes.py
@@ -80,7 +80,7 @@ def get_traffic_data(collection, domain_dict):
         Retrieve list of link sources as a dictionary from database.
         It's a rearranged output of util.util_caline.get_traffic_volumes()
     :param collection: db_air_quality.traffic_volumes
-    :param box_dict: from db_air_quality.util
+    :param domain_dict: from db_air_quality.util
     :return: link_time_series = {link: {timestamp: volume}}
     """
     traffic_links = [

--- a/plotting/plot_weather_data.py
+++ b/plotting/plot_weather_data.py
@@ -1,0 +1,176 @@
+from bson.son import SON
+import datetime
+import numpy as np
+import pymongo
+
+#  This runs into an issue under Mac OS X, thus the workaround.
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import matplotlib
+    matplotlib.use('PS')
+    from matplotlib import pyplot as plt
+
+
+""" Script for plotting the weather data.
+
+    This module plots aggregated weather data from the collection 
+    'weather' of a MongoDB database called 'db_air_pollution' at port 
+    27018. It writes plots into the relative img_path path.
+
+-*- coding: utf-8 -*-
+
+Legal:
+    (C) Copyright IBM 2018.
+
+    This code is licensed under the Apache License, Version 2.0. You may
+    obtain a copy of this license in the LICENSE.txt file in the root 
+    directory of this source tree or at 
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Any modifications or derivative works of this code must retain this
+    copyright notice, and modified files need to carry a notice 
+    indicating that they have been altered from the originals.
+
+    IBM-Review-Requirement: Art30.3
+    Please note that the following code was developed for the project 
+    VaVeL at IBM Research -- Ireland, funded by the European Union under 
+    the Horizon 2020 Program.
+    The project started on December 1st, 2015 and was completed by 
+    December 1st, 2018. Thus, in accordance with Article 30.3 of the 
+    Multi-Beneficiary General Model Grant Agreement of the Program, 
+    there are certain limitations in force  up to December 1st, 2022. 
+    For further details please contact Jakub Marecek 
+    (jakub.marecek@ie.ibm.com) or Gal Weiss (wgal@ie.ibm.com).
+
+If you use the code, please cite our paper:
+https://arxiv.org/abs/1810.09425
+
+Author: 
+    Philipp Hähnel <phahnel@hsph.harvard.edu>
+
+Last updated:
+    2019 - 08 - 02
+
+"""
+
+
+###################
+# Parameters to change
+#
+img_path = '../output/img/weather/'
+
+plot_individual_weather_station_time_series = True
+plot_speed = True
+plot_dir = True
+plot_dir_std = True
+plot_temp = True
+
+timestamp_start = datetime.datetime.strptime(
+    '2017-07-01 00:00:00', '%Y-%m-%d %H:%M:%S').timestamp()
+
+figure_size = (20, 5)
+#
+#
+###################
+
+
+def get_weather_data(collection, site):
+    """
+        retrieve list of weather data from database
+    :param collection: db_air_quality.collection_weather
+    :param site: int
+    :return: [time, speed, dir, std_dir, temp]
+    """
+    coll = collection.find({'site': site}
+                           ).sort([('timestamp', pymongo.ASCENDING)])
+    weather = [((e['timestamp'] - timestamp_start) / (60 * 60 * 24),
+                e['wind_speed'] / 3.6,  # km/h to m/s
+                e['wind_dir'],
+                e['wind_dir_std'],
+                e['temp']
+                )
+               for e in coll]
+    return np.transpose(weather)
+
+
+def plot_weather_data(station, data_x, data_y, ylabel, tag,
+                      error_plot=False, err_data=None):
+    """
+        Plot weather data.
+    :param station: int
+    :param data_x: (list) time series
+    :param data_y: (list)
+    :param ylabel:
+    :param tag: (str) for label and file name
+    :param error_plot: (bool) True if error bar plot instead of normal plot
+    :param err_data: (list) of error bars corresponding to data_y if error_plot==True
+    :return:
+    """
+    fig = plt.figure(figsize=figure_size)
+    sub = fig.add_subplot(1, 1, 1)
+    if error_plot:
+        line_up = plt.errorbar(data_x, data_y, yerr=err_data,
+                               label=tag + ' at site ' + str(station),
+                               fmt='r.')
+    else:
+        line_up, = plt.plot(data_x, data_y, 'r.',
+                            label=tag + ' at site ' + str(station),
+                            markersize=1)
+    loc_x = data_x[0::24 * 7]
+    label_x = [int(l) for l in data_x[0::24 * 7]]
+    plt.xticks(loc_x, label_x)
+    label_y = list(np.linspace(data_y.min(), data_y.max(), 10))
+    plt.yticks(label_y, label_y)
+    sub.grid(which='major')
+    plt.xlabel('Days from 2017-07-01')
+    plt.ylabel(ylabel)
+    plt.legend(handles=[line_up])
+    plt.savefig(img_path + tag + '_' + str(station) + '.pdf')
+    plt.close()
+
+    return None
+
+
+def main():
+    """
+        Connect to database, retrieve weather data and plot for all
+        available stations.
+    :return: None
+    """
+    """ connect to internal Mongo database """
+    client = pymongo.MongoClient('localhost', 27018)
+    # 2017-07-01 01:00:00 to 2018-05-02 14:00:00
+    collection_weather = client.db_air_quality.weather
+
+    stations_pipeline = [{'$group': {'_id': '$site'}},
+                         {'$sort': SON([('_id', 1)])}]
+    stations = [site['_id']
+                for site in collection_weather.aggregate(stations_pipeline)]
+
+    for s, site in enumerate(stations):
+        [time, speed, wdir, std_dir, temp] \
+            = get_weather_data(collection_weather, site)
+        if plot_individual_weather_station_time_series:
+            if plot_speed:
+                plot_weather_data(s, time, speed,
+                                  ylabel='wind speed [m/s]',
+                                  tag='wind speed')
+            if plot_dir:
+                plot_weather_data(s, time, wdir,
+                                  ylabel='wind direction [degrees]; 0 = N',
+                                  tag='wind direction',
+                                  error_plot=True, err_data=std_dir)
+            if plot_dir_std:
+                plot_weather_data(s, time, std_dir,
+                                  ylabel='wind direction std [degrees]',
+                                  tag='wind direction std')
+            if plot_temp:
+                plot_weather_data(s, time, temp,
+                                  ylabel='temperature [C]',
+                                  tag='temperature')
+    return None
+
+
+if __name__ == '__main__':
+    main()

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -7,7 +7,8 @@ import util.util_ml_model as umm
 """ Script for training the ML model on pre-processed data.
 
 Description:
-    This module contains the settings and main loop for training the ML model
+    This module contains the settings and main loop for training the 
+    ML model
 
 -*- coding: utf-8 -*-
 

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -43,7 +43,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 13
+    2019 - 08 - 30
 
 """
 

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -65,14 +65,14 @@ def get_parameters():
         'tiles': [6, 7],  # list of id's to be used in modeling
         # 'tiles': list(range(1, 12 + 1)),
         # model hyper-parameters
-        'num_iterations': 10,
-        'num_hidden_layers': 3,
+        'num_iterations': 11,
+        'num_hidden_layers': 5,
         'num_nodes': 50,
-        'num_epochs': 10,
+        'num_epochs': 50,
         'batch_size': 128,
         'l2_reg_coefficient': 1e-4,  # weights are regularized with l2 norm
-        'starter_learning_rate': 1e-4,
-        'decay_factor': 0.9,  # exponential decay
+        'starter_learning_rate': 1e-3,
+        'decay_factor': 0.95,  # exponential decay
         'train_to_test_split': 0.9,  # train_% + test_% = 1
         'add_previous_labels_to_input': False,
         # ToDo: allow True in update of consistency constraint data
@@ -88,7 +88,7 @@ def get_parameters():
         'do_save_cc': True,
         'do_save_model': True,
         'do_save_estimates': True,
-        'iterations_to_save_estimates': [1, 2, 5, 8],  # 1-based
+        'iterations_to_save_estimates': [1, 2, 5, 10, 20, 30, 40, 50],  # 1-based
         'do_print_status': True,
         # for reproducibility
         'random_seed': None

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -71,7 +71,7 @@ def get_parameters():
         'num_epochs': 10,
         'batch_size': 128,
         'l2_reg_coefficient': 1e-4,  # weights are regularized with l2 norm
-        'starter_learning_rate': 1e-2,
+        'starter_learning_rate': 1e-4,
         'decay_factor': 0.9,  # exponential decay
         'train_to_test_split': 0.9,  # train_% + test_% = 1
         'add_previous_labels_to_input': False,
@@ -88,7 +88,7 @@ def get_parameters():
         'do_save_cc': True,
         'do_save_model': True,
         'do_save_estimates': True,
-        'iterations_to_save_estimates': [0, 1, 2, 5, 8],
+        'iterations_to_save_estimates': [1, 2, 5, 8],  # 1-based
         'do_print_status': True,
         # for reproducibility
         'random_seed': None
@@ -127,9 +127,15 @@ def main():
         print(f'Labels mean: {np.mean(all_data)}')
         print(f'Labels max: {np.max(all_data)}\n')
 
-    for iteration in range(param['num_iterations']):
+    normalisation_stats = collections['data'].find({
+        'util.case': param['case']
+    })[0]['util']['utils']
+
+    # iterations are 1-based
+    for iteration in range(1, param['num_iterations'] + 1):
         mlp_times = umm.run_recursion_cycle(data, mesh, iteration,
-                                            collections['pred'], **param)
+                                            collections['pred'],
+                                            normalisation_stats, **param)
         if param['use_consistency_constraints']:
             ucc.update_consistency_constraints(data, mesh, iteration, **param)
         if param['do_print_status']:

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -62,14 +62,14 @@ def get_parameters():
         'mesh_size': 2,  # tag which identifies pre-processed data
         'tiles': [6, 7],  # list of id's of each of the sub-domain
         # model hyper-parameters
-        'num_iterations': 20,
+        'num_iterations': 5,
         'num_hidden_layers': 4,
         'num_nodes': 42,
-        'num_epochs': 200,
+        'num_epochs': 2000,
         'batch_size': 128,
-        'l2_reg_coefficient': 0.0001,  # weights are regularized with l2 norm
-        'starter_learning_rate': 0.01,
-        'decay_factor': 0.96,  # exponential decay
+        'l2_reg_coefficient': 1e-4,  # weights are regularized with l2 norm
+        'starter_learning_rate': 1e-4,
+        'decay_factor': 0.98,  # exponential decay
         'train_to_test_split': 0.9,  # train_% + test_% = 1
         'add_previous_labels_to_input': False,
         # ToDo: allow True in update of consistency constraint data
@@ -81,9 +81,9 @@ def get_parameters():
         'cc_update_version': 'version 3',
         # check util.util_consistency_constraints
         # saving of output
-        'do_save_benchmark': False,
-        'do_save_cc': False,
-        'do_save_model': False,
+        'do_save_benchmark': True,
+        'do_save_cc': True,
+        'do_save_model': True,
         'do_save_estimates': False,
         'iterations_to_save_estimates': [0] + list(range(4, 10000, 5)),
         'do_print_status': True,
@@ -106,6 +106,8 @@ def main():
               )
         print(f'Hidden layers: {param["num_hidden_layers"]}\t '
               f'nodes: {param["num_nodes"]}\t')
+        print(f'learning rate: {param["starter_learning_rate"]}\t '
+              f'decay rate: {param["decay_factor"]}')
         print(f'Lambda: {param["cc_reg_coefficient"]}\t '
               f'kappa: {param["kappa"]}\t '
               f'epsilon: {param["epsilon"]}\n')

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -42,7 +42,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 01
+    2019 - 08 - 13
 
 """
 
@@ -51,21 +51,23 @@ tf.logging.set_verbosity(tf.logging.INFO)
 
 def get_parameters():
     """
-    use 'mesh_size': 2 for synthetic example
+    use 'mesh_size': 2 for synthetic example (Demo)
     use 'mesh_size': 12 for Dublin example
     select 'tiles': [i, j, k] for the tiles i, j, k that are part of the run
     The synthetic example has the two tiles 6 and 7.
     :return:
     """
-    param = {  # data parameters
-        'case': 'Demo',  # retrieves utilities based on this tag
-        'mesh_size': 2,  # tag which identifies pre-processed data
-        'tiles': [6, 7],  # list of id's of each of the sub-domain
+    param = {
+        # tags for data retrieval:
+        'case': 'Demo',  # 'Dublin' or 'Demo'
+        'mesh_size': 2,  # number of sub-domains in pre-processed collection
+        'tiles': [6, 7],  # list of id's to be used in modeling
+        # 'tiles': list(range(1, 12 + 1)),
         # model hyper-parameters
-        'num_iterations': 5,
+        'num_iterations': 10,
         'num_hidden_layers': 4,
         'num_nodes': 42,
-        'num_epochs': 2000,
+        'num_epochs': 50,
         'batch_size': 128,
         'l2_reg_coefficient': 1e-4,  # weights are regularized with l2 norm
         'starter_learning_rate': 1e-4,
@@ -81,11 +83,11 @@ def get_parameters():
         'cc_update_version': 'version 3',
         # check util.util_consistency_constraints
         # saving of output
-        'do_save_benchmark': True,
+        'do_save_benchmark': False,
         'do_save_cc': True,
         'do_save_model': True,
         'do_save_estimates': False,
-        'iterations_to_save_estimates': [0] + list(range(4, 10000, 5)),
+        'iterations_to_save_estimates': [0, 1, 2, 5, 8],
         'do_print_status': True,
         # for reproducibility
         'random_seed': None

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import numpy as np
 import tensorflow as tf
 
@@ -65,13 +66,13 @@ def get_parameters():
         # 'tiles': list(range(1, 12 + 1)),
         # model hyper-parameters
         'num_iterations': 10,
-        'num_hidden_layers': 4,
-        'num_nodes': 42,
-        'num_epochs': 50,
+        'num_hidden_layers': 3,
+        'num_nodes': 50,
+        'num_epochs': 10,
         'batch_size': 128,
         'l2_reg_coefficient': 1e-4,  # weights are regularized with l2 norm
-        'starter_learning_rate': 1e-4,
-        'decay_factor': 0.98,  # exponential decay
+        'starter_learning_rate': 1e-2,
+        'decay_factor': 0.9,  # exponential decay
         'train_to_test_split': 0.9,  # train_% + test_% = 1
         'add_previous_labels_to_input': False,
         # ToDo: allow True in update of consistency constraint data
@@ -83,10 +84,10 @@ def get_parameters():
         'cc_update_version': 'version 3',
         # check util.util_consistency_constraints
         # saving of output
-        'do_save_benchmark': False,
+        'do_save_benchmark': True,
         'do_save_cc': True,
         'do_save_model': True,
-        'do_save_estimates': False,
+        'do_save_estimates': True,
         'iterations_to_save_estimates': [0, 1, 2, 5, 8],
         'do_print_status': True,
         # for reproducibility
@@ -101,6 +102,7 @@ def main():
     if param['random_seed'] is None:
         param['random_seed'] = np.random.randint(2147483647)
     np.random.seed(param['random_seed'])
+    param['start_time'] = datetime.strftime(datetime.now(), '%y%m%d-%H%M%S')
 
     if param['do_print_status']:
         print(f'Using pre-processed data for {param["case"]} '
@@ -119,10 +121,11 @@ def main():
     data = umm.get_data(collections['data'], mesh, **param)
     if param['do_print_status']:
         print('Data loaded successfully.')
-        print(f'Labels min: {np.min(list(data["labels"].values()))}')
-        print(f'Labels median: {np.median(list(data["labels"].values()))}')
-        print(f'Labels mean: {np.mean(list(data["labels"].values()))}')
-        print(f'Labels max: {np.max(list(data["labels"].values()))}\n')
+        all_data = np.concatenate(list(data['labels'].values()))
+        print(f'Labels min: {np.min(all_data)}')
+        print(f'Labels median: {np.median(all_data)}')
+        print(f'Labels mean: {np.mean(all_data)}')
+        print(f'Labels max: {np.max(all_data)}\n')
 
     for iteration in range(param['num_iterations']):
         mlp_times = umm.run_recursion_cycle(data, mesh, iteration,

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -67,7 +67,7 @@ def get_parameters():
         'num_epochs': 200,
         'batch_size': 128,
         'l2_reg_coefficient': 0.0001,  # weights are regularized with l2 norm
-        'starter_learning_rate': 0.001,
+        'starter_learning_rate': 0.01,
         'decay_factor': 0.96,  # exponential decay
         'train_to_test_split': 0.9,  # train_% + test_% = 1
         'add_previous_labels_to_input': False,
@@ -114,6 +114,10 @@ def main():
     data = umm.get_data(collections['data'], mesh, **param)
     if param['do_print_status']:
         print('Data loaded successfully.')
+        print(f'Labels min: {np.min(list(data["labels"].values()))}')
+        print(f'Labels median: {np.median(list(data["labels"].values()))}')
+        print(f'Labels mean: {np.mean(list(data["labels"].values()))}')
+        print(f'Labels max: {np.max(list(data["labels"].values()))}\n')
 
     for iteration in range(param['num_iterations']):
         mlp_times = umm.run_recursion_cycle(data, mesh, iteration,

--- a/run/run_pre_processing.py
+++ b/run/run_pre_processing.py
@@ -73,7 +73,7 @@ Author:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 13
+    2019 - 08 - 30
 
 """
 

--- a/run/run_pre_processing.py
+++ b/run/run_pre_processing.py
@@ -420,7 +420,7 @@ def main():
                                                   traffic_links_sorted)
 
         print('Getting Caline data ...')
-        caline_estimates, receptor_list = uda.get_caline_estimates(
+        caline_estimates, receptor_list = uda.get_estimates(
             collection_caline_estimates,
             param['date start'], param['date end'],
             **tag_dict

--- a/run/run_pre_processing.py
+++ b/run/run_pre_processing.py
@@ -18,8 +18,10 @@ Description:
 
         sub_domain = id
         run_tag    = run_tag
-        input      = [timestamp, wind_dir, wind_speed, wind_dir_std, temperature, 
-                      lat_link1, lon_link1, lat_link2, lon_link2, volume, ... x20, 
+        input      = [timestamp, 
+                      wind_dir, wind_speed, wind_dir_std, temperature, 
+                      lat_link1, lon_link1, lat_link2, lon_link2, volume, 
+                      ... x20, 
                       lat, lon, ... x20]
         labels     = [NO2_value, PM10_value, PM25_value, ... x20]
 
@@ -29,7 +31,8 @@ Description:
     that is coming from traffic. Taking the background pollution levels 
     into account, the collected output is given by
 
-        output = Caline(traffic, weather, default background) - default background
+        output = Caline(traffic, weather, default background) 
+                 - default background
 
     The default background is a static value, whereas the real 
     background depends on the time. In order to only model the 
@@ -70,7 +73,7 @@ Author:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 01
+    2019 - 08 - 13
 
 """
 
@@ -79,25 +82,27 @@ def get_parameters():
     """
     :return:
     """
-    #  time slice (2017-07-01 01:00:00 to 2018-05-02 14:00:00)
-    param = {'date start': datetime.datetime(2017, 7, 1, 1),
-             'date end': datetime.datetime(2018, 5, 2, 23),
-             # 'sub domain selection': list(range(1, 12 + 1)),
-             'sub domain selection': [6, 7],
-             'pad links with zeroes': False,
-             'pollutants': ['NO2']  # , 'PM10', 'PM25'
-             }
-    # runs selectors from the caline_estimates
-    distances = [
-        5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103
-    ]  # Demo
     # distances = [
-    #     6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
-    # ]  # Dublin
-    param['tags'] = [{'run_tag': '2019-07-04',
-                      'contour_distance': dist,
-                      'case': 'Demo'}
-                     for dist in distances]
+    #     5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103
+    # ]  # Demo
+    distances = [
+        6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
+    ]  # Dublin
+    param = {
+        #  runs selectors from the caline_estimates
+        'tags': [{'run_tag': '2019-07-04',
+                  'contour_distance': dist,
+                  'case': 'Dublin'
+                  } for dist in distances],
+        #  time slice (2017-07-01 01:00:00 to 2018-05-02 14:00:00)
+        'date start': datetime.datetime(2017, 7, 1, 1),
+        'date end': datetime.datetime(2018, 5, 2, 23),
+        'sub domain selection': list(range(1, 12 + 1)),
+        # 'sub domain selection': [6, 7],
+        #  if input should have the same size for all tiles:
+        'pad links with zeroes': False,
+        'pollutants': ['NO2']  # , 'PM10', 'PM25'
+    }
     return param
 
 
@@ -111,11 +116,10 @@ def pre_process(collection_pre, mesh,
 
         TODO: make pre-processed receptors easily findable
 
-    :param date_start:
-    :param date_end:
     :param collection_pre:
     :param mesh:
-    :param weather_data: {timestamp: [wind_dir, wind_speed, wind_dir_std, temp]}
+    :param weather_data:
+        {timestamp: [wind_dir, wind_speed, wind_dir_std, temp]}
     :param traffic_volumes:
     :param utilities:
     :param caline_estimates: output of util_db_access.get_caline_estimates()
@@ -132,7 +136,7 @@ def pre_process(collection_pre, mesh,
         return normalize(_timestamp, time_mean, time_std)
 
     def normalize_weather(_weather_list):
-        """ :param _weather_list: [wind_dir, wind_speed, wind_dir_std, temp] """
+        """ :param _weather_list: [wind_dir, wind_spd, wind_dir_std, temp] """
         return list(
             normalize(np.asarray(_weather_list), weather_mean, weather_std))
 
@@ -300,10 +304,14 @@ def main():
             Get traffic data.
             Get Caline estimates.
             Pre-process into the form
-                input = [timestamp, wind_dir, wind_speed, wind_dir_std, temperature,
-                         lat_src_start, lon_src_start, lat_src_end, lon_src_end, volume, ... x20,
+                input = [timestamp,
+                         wind_dir, wind_speed, wind_dir_std, temperature,
+                         lat_src_start, lon_src_start,
+                         lat_src_end, lon_src_end, volume,
+                         ... x20,
                          lat_rec, lon_rec, ... x20]
-                labels = [rec_NO2_value, rec_PM10_value, rec_PM25_value, ... x20]
+                labels = [rec_NO2_value, rec_PM10_value, rec_PM25_value,
+                          ... x20]
 
     :return: None
     """

--- a/util/util_db_access.py
+++ b/util/util_db_access.py
@@ -38,7 +38,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 06
+    2019 - 08 - 30
 
 """
 

--- a/util/util_domain_decomposition.py
+++ b/util/util_domain_decomposition.py
@@ -252,7 +252,8 @@ def get_neighboring_domains(domain_dict):
                 for edge in edges:
                     for other_edge in other_edges:
                         for point in edge:
-                            if (distance_point_from_line(point, other_edge) == 0
+                            if (distance_point_from_line(point,
+                                                         other_edge) == 0
                                     and point not in intersection):
                                 intersection.append(list(point))
                         for point in other_edge:

--- a/util/util_ml_model.py
+++ b/util/util_ml_model.py
@@ -51,7 +51,7 @@ Authors:
     Fearghal O'Donncha <feardonn@ie.ibm.com>
 
 Last updated:
-    2019 - 08 - 01
+    2019 - 08 - 30
 
 """
 

--- a/util/util_ml_model.py
+++ b/util/util_ml_model.py
@@ -178,6 +178,25 @@ def multilayer_perceptron(input_data, weights, biases, num_hidden_layers=4):
     return out_layer
 
 
+def get_learning_rate(epoch, total_batch, **kwargs):
+    if epoch < 5:
+        lr = 1e-2
+    # elif epoch < 10:
+    #     lr = 1e-1
+    # elif epoch < 20:
+    #     lr = 1e-2
+    # elif epoch < 30:
+    #     lr = 1e-3
+    # elif epoch < 50:
+    #     lr = 1e-4
+    else:
+        decay_steps = 5000
+        lr = (kwargs['starter_learning_rate']
+              * kwargs['decay_factor'] ** (epoch * total_batch / decay_steps)
+        )
+    return lr
+
+
 def run_recursion_cycle(data, mesh, iteration, collection_mlp_estim, **kwargs):
     """
     :param data:
@@ -356,6 +375,7 @@ def run_recursion_cycle(data, mesh, iteration, collection_mlp_estim, **kwargs):
         )  # based on 100%
 
         global_step = tf.Variable(0, trainable=False)
+        # learning rate is defined based on epoch
         learning_rate = tf.placeholder(tf.float32)
         optimizer = tf.train.AdamOptimizer(
             learning_rate=learning_rate
@@ -432,24 +452,7 @@ def run_recursion_cycle(data, mesh, iteration, collection_mlp_estim, **kwargs):
                     # -> what are the previous time stamp labels for
                     # the new boundary receptors?
 
-                    if epoch < 5:
-                        lr = 1e-2
-                    # elif epoch < 10:
-                    #     lr = 1e-1
-                    # elif epoch < 20:
-                    #     lr = 1e-2
-                    # elif epoch < 30:
-                    #     lr = 1e-3
-                    # elif epoch < 50:
-                    #     lr = 1e-4
-                    else:
-                        decay_steps = 5000
-                        lr = (
-                            kwargs['starter_learning_rate']
-                            * kwargs['decay_factor'] ** (epoch * total_batch
-                                                         / decay_steps)
-                        )
-
+                    lr = get_learning_rate(epoch, total_batch, **kwargs)
                     sess.run(optimizer,
                              feed_dict={tf_data: batch_xs, tf_labels: batch_ys,
                                         tf_cc_input: cc_batch_xs,

--- a/util/util_ml_model.py
+++ b/util/util_ml_model.py
@@ -179,7 +179,8 @@ def multilayer_perceptron(input_data, weights, biases, num_hidden_layers=4):
         hidden = tf.nn.relu(hidden)
 
     hidden = dense(hidden, weights['out'], biases['out'])
-    out_layer = tf.nn.relu(hidden)
+    # out_layer = tf.nn.relu(hidden)
+    out_layer = hidden
     return out_layer
 
 

--- a/util/util_save_benchmarks.py
+++ b/util/util_save_benchmarks.py
@@ -152,7 +152,7 @@ def save_ml_estimates(estimates, inputs, iteration, tile, collection_mlp_estim,
                     'epochs': kwargs['num_epochs'],
                     'batch size': kwargs['batch_size'],
                     'learning rate': kwargs['starter_learning_rate'],
-                    'comment': kwargs['comment'],
+                    'comment': kwargs['cc_update_version'],
                     'seed': kwargs['random_seed']
                 }
             })

--- a/util/util_save_benchmarks.py
+++ b/util/util_save_benchmarks.py
@@ -41,7 +41,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 14
+    2019 - 08 - 30
 
 """
 
@@ -166,7 +166,7 @@ def save_benchmarks(tile, iteration, num_instances, num_input, num_classes,
     return None
 
 
-def save_ml_estimates(estimates, inputs, iteration, tile, collection_mlp_estim,
+def save_ml_estimates(estimates, inputs, iteration, collection_mlp_estim,
                       normalisation_stats, **kwargs):
 
     def inv_normalise(value, mean, std):
@@ -214,23 +214,6 @@ def save_ml_estimates(estimates, inputs, iteration, tile, collection_mlp_estim,
                         'seed': kwargs['random_seed']
                     }
                 })
-                # save.append({
-                #     'tile': tile,
-                #     'input': list(xinput),
-                #     'labels': list(estimates[i]),
-                #     'settings': {
-                #         'gamma': kwargs['cc_reg_coefficient'],
-                #         'kappa': kwargs['kappa'],
-                #         'iteration': iteration,
-                #         'layers': kwargs['num_hidden_layers'],
-                #         'neurons': kwargs['num_nodes'],
-                #         'epochs': kwargs['num_epochs'],
-                #         'batch size': kwargs['batch_size'],
-                #         'learning rate': kwargs['starter_learning_rate'],
-                #         'comment': kwargs['cc_update_version'],
-                #         'seed': kwargs['random_seed']
-                #     }
-                # })
                 # collect estimates in a batch and then write batch to database
                 if len(save) < 100000:
                     continue


### PR DESCRIPTION
The biggest change is that the pre-processing step does no longer prepare the data in exactly the same way as it was handed to Caline, but splits the labels by each individual receptor. Further, the ML model estimates are stored in the database in essentially the same format as the Caline estimates, making their retrieval much simpler. This however now leads to a substantial memory burden when retrieving the samples from the database. For future use, it may be best to move the collection step into the loop over each subdomains, and only retrieve the data for the specific subdomain. This takes a toll on the overall runtime though.

Other improvements are concerning the plotting of the data, most notably the script for plotting the spacial receptor and line source map, the time series data, and the contour maps of the estimated pollution concentration.

Removing the ReLu activation from the last layer is crucial to get any kind of sensible output.